### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/Android-CI-Espresso.yml
+++ b/.github/workflows/Android-CI-Espresso.yml
@@ -19,13 +19,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Android SDK
-        uses: hannesa2/action-android/install-sdk@0.0.7.5
+        uses: hannesa2/action-android/install-sdk@0.0.7.7
       - name: Build project
         run: ./gradlew assembleDebug
       - name: Run tests
         run: ./gradlew test
       - name: Run instrumentation tests
-        uses: hannesa2/action-android/emulator-run-cmd@0.0.7.5
+        uses: hannesa2/action-android/emulator-run-cmd@0.0.7.7
         with:
           cmd: ./gradlew connectedWithoutVuforiaDebugAndroidTest
           api: 28
@@ -48,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Android SDK
-        uses: hannesa2/action-android/install-sdk@0.0.7.5
+        uses: hannesa2/action-android/install-sdk@0.0.7.7
       - name: Gradle checks
         run: ./gradlew check
       - name: Archive Lint report

--- a/.github/workflows/Android-CI-release.yml
+++ b/.github/workflows/Android-CI-release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           java-version: 1.8
       - name: Install Android SDK
-        uses: hannesa2/action-android/install-sdk@0.0.7.5
+        uses: hannesa2/action-android/install-sdk@0.0.7.7
       - name: Build project
         run: ./gradlew clean build
         env:


### PR DESCRIPTION
According to this information https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/ , the following statements are written.

> Action authors who are using the toolkit should update the @actions/core package to v1.2.6 or greater to get the updated addPath and exportVariable functions.